### PR TITLE
fix: allow inserting array

### DIFF
--- a/src/Helper/DbalHelperTrait.php
+++ b/src/Helper/DbalHelperTrait.php
@@ -100,6 +100,9 @@ trait DbalHelperTrait
                 if (is_bool($value)) {
                     $type = ParameterType::BOOLEAN;
                 }
+                if (is_array($value)) {
+                    $value = json_encode($value);
+                }
                 $queryBuilder
                     ->setValue($columnName, ':' . $columnName)
                     ->setParameter($columnName, $value, $type);
@@ -218,6 +221,9 @@ trait DbalHelperTrait
                 $type = ParameterType::STRING;
                 if (is_bool($value)) {
                     $type = ParameterType::BOOLEAN;
+                }
+                if (is_array($value)) {
+                    $value = json_encode($value);
                 }
                 $queryBuilder
                     ->set($columnName, ':' . $columnName)


### PR DESCRIPTION
PDO nav tipa array vai json, tāpēc tiek izmantots string, bet masīvu string laukā nevar insertot. Datubāzē array lauks ir json, līdz ar ko masīvu vajag insertot/updeitot kā json string

piemēram, user->roles